### PR TITLE
#119 - Remove back to selection button on connect

### DIFF
--- a/src/components/connect/Company.vue
+++ b/src/components/connect/Company.vue
@@ -25,12 +25,6 @@
         </div>
       </div>
     </div>
-
-    <SLink
-      lighter-background
-      @click="back">
-      Return to selection
-    </SLink>
   </div>
 </template>
 

--- a/src/components/connect/Developer.vue
+++ b/src/components/connect/Developer.vue
@@ -36,11 +36,6 @@
           src="~/assets/images/connect/btc.svg"></div>
       </div>
     </div>
-    <SLink
-      lighter-background
-      @click="back">
-      Return to selection
-    </SLink>
   </div>
 </template>
 

--- a/src/components/connect/Other.vue
+++ b/src/components/connect/Other.vue
@@ -32,12 +32,6 @@
         </div>
       </div>
     </div>
-
-    <SLink
-      lighter-background
-      @click="back">
-      Return to selection
-    </SLink>
   </div>
 </template>
 

--- a/src/components/connect/Student.vue
+++ b/src/components/connect/Student.vue
@@ -37,13 +37,6 @@
         Here are some of the companies and organizations that our alumni have gone on to work with:
       </p>
     </div>
-
-    <SLink
-      lighter-background
-      class="back"
-      @click="back">
-      Return to selection
-    </SLink>
   </div>
 </template>
 


### PR DESCRIPTION
Removed "Back to Selection" buttons on connect page. It is redundant because of the new back buttons, and was causing alignment issues.