### PR TITLE
Space mono

### DIFF
--- a/components/VPersonCardFull.vue
+++ b/components/VPersonCardFull.vue
@@ -105,7 +105,7 @@ export default {
 }
 
 .title {
-  font-family: "Space Mono";
+  font-family: SpaceMono;
   font-weight: 500;
   margin-top: 0;
 }

--- a/components/VProjectModal.vue
+++ b/components/VProjectModal.vue
@@ -20,28 +20,38 @@
           <p class="service">{{ project.services }}</p>
           <p class="tech">{{ project.technologies }}</p>
         </div>
-        <div
-          class="images">
-          <img
-            v-for="(image, index) in project.images"
-            :key="`image-${index}`"
-            :src="image"
-            :alt="`Project Image ${index}`"
-            class="projectImage" >
+        <div class="activeDetailSidebar">
+          <v-person-card-mini
+            v-for="person in project.people"
+            :key="person.id"
+            :icon="person.iconURL">
+            <template slot="name">{{ person.name }}</template>
+            <template slot="position">{{ person.role }}</template>
+          </v-person-card-mini>
         </div>
-        
       </div>
-      <div class="activeDetailSidebar">
-        <v-person-card-mini
-          v-for="person in project.people"
-          :key="person.id"
-          :icon="person.iconURL">
-          <template slot="name">{{ person.name }}</template>
-          <template slot="position">{{ person.role }}</template>
-        </v-person-card-mini>
-      </div>
+      <!-- <div
+        v-if="project.images.length > 0"
+        class="preview-images">
+        <img
+          v-for="index in 3"
+          :key="`image-${index}`"
+          :src="project.images[index - 1]"
+          :alt="`Project Image ${index}`"
+          class="projectImage" >
+      </div> -->
     </div>
-      
+    <!-- <div
+      v-if="project.images.length > 0"
+      class="images">
+      <img
+        v-for="(image, index) in project.images"
+        v-if="index>2"
+        :key="`image-${index}`"
+        :src="image"
+        :alt="`Project Image ${index}`"
+        class="projectImage" >
+    </div> -->
   </div>
 </template>
 

--- a/pages/connect.vue
+++ b/pages/connect.vue
@@ -52,7 +52,7 @@ export default {
 }
 
 .header {
-  font-family: "Space Mono";
+  font-family: SpaceMono;
   font-size: 4.768em;
   margin: 0;
 }

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -184,6 +184,10 @@ export default {
   margin: auto;
 }
 
+div.project {
+  width: auto;
+}
+
 #connectSection:before {
   left: 0;
   text-align: left;


### PR DESCRIPTION
There were two instances in which Space Mono was incorrectly named in CSS. There were also some issues on the home page in project card sizing that were fixed.

This also turns off project modal images until we fix the issues with them and curate them, because in their current state, it's ugly.